### PR TITLE
Update the result when a disabled filter is edited and do not enable it on edit

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -43,12 +43,14 @@ function save () {
 
     self.emit('showLoader');
 
-    self.emit('setFilters', [filter]);
+    self.emit('setFilters', [filter], false, false, function (err, data) {
 
-    var createKey = 'create';
-    if (self.domRefs.controls[createKey]) {
-        self.domRefs.controls[createKey].focus();
-    }
+        var createKey = 'create';
+        if (self.domRefs.controls[createKey]) {
+            self.domRefs.controls[createKey].focus();
+        }
+
+    });
 }
 
 function edit (hash) {

--- a/ui.js
+++ b/ui.js
@@ -43,11 +43,6 @@ function save () {
 
     self.emit('showLoader');
 
-    // if the filter is disabled, enable it
-    if ((self.filters[filter.hash] || {}).disabled) {
-        enable.call(self, filter.hash);
-    }
-
     self.emit('setFilters', [filter]);
 
     var createKey = 'create';


### PR DESCRIPTION
Related to #27. Changes:
- Saving a disabled filter does not enable it back. This solves solution B from the issue.
- Started to correctly use a callback with the `setFilters` event. This solves solution A from the issue: saving the filter also updates the query, not only the UI.